### PR TITLE
mount rpool/nixos/var too

### DIFF
--- a/docs/Getting Started/NixOS/Root on ZFS.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS.rst
@@ -302,13 +302,14 @@ System Installation
       zfs create -o mountpoint=legacy rpool/nixos/home
       mkdir "${MNT}"/home
       mount -t zfs rpool/nixos/home "${MNT}"/home
-      zfs create -o mountpoint=legacy  rpool/nixos/var
+      zfs create -o mountpoint=legacy rpool/nixos/var
       zfs create -o mountpoint=legacy rpool/nixos/var/lib
       zfs create -o mountpoint=legacy rpool/nixos/var/log
       zfs create -o mountpoint=none bpool/nixos
       zfs create -o mountpoint=legacy bpool/nixos/root
       mkdir "${MNT}"/boot
       mount -t zfs bpool/nixos/root "${MNT}"/boot
+      mount -t zfs rpool/nixos/var "${MNT}"/var
       mkdir -p "${MNT}"/var/log
       mkdir -p "${MNT}"/var/lib
       mount -t zfs rpool/nixos/var/lib "${MNT}"/var/lib

--- a/docs/Getting Started/NixOS/Root on ZFS.rst
+++ b/docs/Getting Started/NixOS/Root on ZFS.rst
@@ -302,14 +302,13 @@ System Installation
       zfs create -o mountpoint=legacy rpool/nixos/home
       mkdir "${MNT}"/home
       mount -t zfs rpool/nixos/home "${MNT}"/home
-      zfs create -o mountpoint=legacy rpool/nixos/var
+      zfs create -o mountpoint=none   rpool/nixos/var
       zfs create -o mountpoint=legacy rpool/nixos/var/lib
       zfs create -o mountpoint=legacy rpool/nixos/var/log
       zfs create -o mountpoint=none bpool/nixos
       zfs create -o mountpoint=legacy bpool/nixos/root
       mkdir "${MNT}"/boot
       mount -t zfs bpool/nixos/root "${MNT}"/boot
-      mount -t zfs rpool/nixos/var "${MNT}"/var
       mkdir -p "${MNT}"/var/log
       mkdir -p "${MNT}"/var/lib
       mount -t zfs rpool/nixos/var/lib "${MNT}"/var/lib


### PR DESCRIPTION
It is quite confusing to have a dataset `rpool/nixos/var`, which is not normally mounted.

Also see https://github.com/ne9z/dotfiles-flake/pull/6

### Discussion

I see two options here:

1. mark it `mountpoint=none` instead of `legacy` to clearly show that it's not meant to be mounted.
2. mount the dataset, as this PR does.

Let me know what your prefer.